### PR TITLE
Fix wp page title separator position

### DIFF
--- a/wordpress/theme/header.php
+++ b/wordpress/theme/header.php
@@ -11,7 +11,7 @@
 	<title>
 		<?php
 		// Page title | Site name | Site description
-		wp_title( '|', true, true );
+		wp_title( '|', true, "right" );
 		bloginfo( 'name' );
 		$site_description = get_bloginfo( 'description', 'display' );
 		if ( $site_description && ( is_home() || is_front_page() ) ) {


### PR DESCRIPTION
# Pull Request

ClickUp link: <https://app.clickup.com/t/xxxxxx>

## Acceptance criteria

* [ ] Passes all regression tests
* [ ] Is cross-browser compatible
* [ ] Is cross-device compatible
* [ ] Fullfils General Acceptance Criteria (see Wiki)
* [ ] Fullfils Specific Acceptance Criteria (see ClickUp card)
* [ ] Adheres to code standards
* [ ] All code reviews have been addressed
* [ ] No linting errors

QA Wiki: [Generic Criteria](https://wiki.graffino.net/doc/generic-criteria-kHpwt8jdKP)
